### PR TITLE
Create ui-win-lose

### DIFF
--- a/feature/ui-win-lose
+++ b/feature/ui-win-lose
@@ -1,0 +1,116 @@
+/* ========================================
+  ui.js - 勝敗演出 & 駒移動音（B担当用）
+  - 勝利 / 敗北時に音楽再生
+  - 画面中央にメッセージ表示
+  - 駒を動かしたときに音を再生
+======================================== */
+
+// ----------------------------
+// 音声ファイル読み込み
+// ----------------------------
+const moveSound = new Audio('./assets/sounds/move.mp3'); // 駒を動かした音
+const winSound  = new Audio('./assets/sounds/win.mp3');  // 勝利音
+const loseSound = new Audio('./assets/sounds/lose.mp3'); // 敗北音
+
+// ----------------------------
+// メッセージ表示用 div を作成
+// ----------------------------
+const messageDiv = document.createElement('div');
+messageDiv.style.position = 'fixed';             // 画面上に固定
+messageDiv.style.top = '50%';                    // 縦中央
+messageDiv.style.left = '50%';                   // 横中央
+messageDiv.style.transform = 'translate(-50%, -50%)'; // 完全中央
+messageDiv.style.padding = '20px 40px';         // 内側余白
+messageDiv.style.background = 'rgba(0,0,0,0.8)'; // 半透明黒背景
+messageDiv.style.color = '#fff';                // 白文字
+messageDiv.style.fontSize = '24px';             // 文字サイズ
+messageDiv.style.borderRadius = '10px';         // 角丸
+messageDiv.style.textAlign = 'center';          // 中央揃え
+messageDiv.style.zIndex = '9999';               // 前面に表示
+messageDiv.style.display = 'none';              // 初期は非表示
+document.body.appendChild(messageDiv);          // body に追加
+
+// ----------------------------
+// 駒移動音再生関数
+// ----------------------------
+function playMoveSound() {
+  moveSound.currentTime = 0; // 再生位置を先頭に戻す
+  moveSound.play();          // 再生
+}
+
+// ----------------------------
+// 勝利演出関数
+// ----------------------------
+function showWinMessage(prefName) {
+  messageDiv.innerText = `
+
+
+/* ========================================
+  ui.js - 勝敗演出（B担当用）
+  - 勝利 / 敗北時に音楽再生
+  - 画面中央にメッセージ表示
+======================================== */
+
+// 勝利用サウンドファイルを読み込む
+const winSound = new Audio('./assets/sounds/win.mp3');
+// 敗北用サウンドファイルを読み込む
+const loseSound = new Audio('./assets/sounds/lose.mp3');
+
+// メッセージ表示用の div を作成して画面に追加
+const messageDiv = document.createElement('div');
+messageDiv.style.position = 'fixed';             // 画面上に固定
+messageDiv.style.top = '50%';                    // 縦中央
+messageDiv.style.left = '50%';                   // 横中央
+messageDiv.style.transform = 'translate(-50%, -50%)'; // 完全中央に配置
+messageDiv.style.padding = '20px 40px';         // 内側余白
+messageDiv.style.background = 'rgba(0,0,0,0.8)';// 半透明黒背景
+messageDiv.style.color = '#fff';                // 白文字
+messageDiv.style.fontSize = '24px';             // 文字サイズ
+messageDiv.style.borderRadius = '10px';         // 角丸
+messageDiv.style.textAlign = 'center';          // 中央揃え
+messageDiv.style.zIndex = '9999';               // 他の要素より前面に表示
+messageDiv.style.display = 'none';              // 最初は非表示
+document.body.appendChild(messageDiv);          // body に追加
+
+// ----------------------------
+// 勝利演出関数
+// prefName: 勝利した武将の名前
+// ----------------------------
+function showWinMessage(prefName) {
+  messageDiv.innerText = `勝利！${prefName}の武将を倒した！🎉`; // メッセージ設定
+  messageDiv.style.background = 'rgba(31,111,235,0.9)';           // 青系背景
+  messageDiv.style.display = 'block';                              // 表示
+
+  // 音を再生
+  winSound.currentTime = 0;  // 再生位置を先頭に戻す
+  winSound.play();
+
+  // 3秒後にメッセージを自動非表示
+  setTimeout(() => {
+    messageDiv.style.display = 'none';
+  }, 3000);
+}
+
+// ----------------------------
+// 敗北演出関数
+// prefName: 敗北した武将の名前
+// ----------------------------
+function showLoseMessage(prefName) {
+  messageDiv.innerText = `敗北…${prefName}の武将に負けた…💦\nちろり～ん、鼻から牛乳～`; // メッセージ設定
+  messageDiv.style.background = 'rgba(235,31,31,0.9)'; // 赤系背景
+  messageDiv.style.display = 'block';                  // 表示
+
+  // 音を再生
+  loseSound.currentTime = 0; // 再生位置を先頭に戻す
+  loseSound.play();
+
+  // 3秒後にメッセージを自動非表示
+  setTimeout(() => {
+    messageDiv.style.display = 'none';
+  }, 3000);
+}
+
+/* 使い方例
+  勝利時: showWinMessage('徳川家康')
+  敗北時: showLoseMessage('徳川家康')
+*/


### PR DESCRIPTION
- src/ui.js に勝敗演出用コードを追加
- assets/sounds/win.mp3: 勝利ファンファーレ（フリー素材）
- assets/sounds/lose.mp3: 敗北音（フリー素材）
- 音声再生＋メッセージ表示がブラウザ上で動作