### PR TITLE
Update piece image map to include assets directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,8 +431,31 @@
         return map[type] ?? type;
       }
 
+      const PIECE_IMAGE_FILES = {
+        [PIECE.FUHYO]: 'assets/pieces/FUHYO.png',
+        [PIECE.KYOSHA]: 'assets/pieces/KYOSHA.png',
+        [PIECE.KEIMA]: 'assets/pieces/KEIMA.png',
+        [PIECE.GINSHO]: 'assets/pieces/GINSHO.png',
+        [PIECE.KINSHO]: 'assets/pieces/KINSHO.png',
+        [PIECE.KAKUGYO]: 'assets/pieces/KAKUGYO.png',
+        [PIECE.HISHA]: 'assets/pieces/HISHA.png',
+        [PIECE.OSHO]: 'assets/pieces/OSHO.png',
+        [PIECE.TOKIN]: 'assets/pieces/TOKIN.png',
+        [PIECE.NARIKYOSHA]: 'assets/pieces/NARIKYOSHA.png',
+        [PIECE.NARIKEIMA]: 'assets/pieces/NARIKEIMA.png',
+        [PIECE.NARIGINSHO]: 'assets/pieces/NARIGINSHO.png',
+        [PIECE.RYUMA]: 'assets/pieces/RYUMA.png',
+        [PIECE.RYUO]: 'assets/pieces/RYUO.png'
+      };
+
+      const PIECE_IMAGE_FALLBACK = 'assets/pieces/black_king2.png';
+
       function getPieceImagePath(type) {
-        return `./assets/pieces/${type}.png`;
+        const fileName = PIECE_IMAGE_FILES[type];
+        if (!fileName) {
+          console.warn(`Unknown piece type: ${type}`);
+        }
+        return new URL(fileName ?? PIECE_IMAGE_FALLBACK, import.meta.url).href;
       }
 
       const moveSound = new Audio('./assets/audio/sfx/move.mp3');


### PR DESCRIPTION
## Summary
- prefix all mapped piece images with the assets directory so each path is fully qualified
- adjust the fallback path to match the assets directory structure and reuse the same helper

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e39aafe6e4832e863d8642d7786608