### PR TITLE
Fix piece image loading on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
         if (!fileName) {
           console.warn(`Unknown piece type: ${type}`);
         }
-        return new URL(fileName ?? PIECE_IMAGE_FALLBACK, import.meta.url).href;
+        return fileName ?? PIECE_IMAGE_FALLBACK;
       }
 
       const moveSound = new Audio('./assets/audio/sfx/move.mp3');


### PR DESCRIPTION
## Summary
- return relative asset paths from `getPieceImagePath` so piece images resolve correctly on GitHub Pages

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e3a05a69a8832ea3863bfc350fb8b4