### PR TITLE
Fix board highlight blocking square clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
         position: absolute;
         inset: 6px;
         border-radius: 8px;
+        pointer-events: none;
       }
 
       .highlight-move::after {


### PR DESCRIPTION
## Summary
- disable pointer events on move and capture highlight overlays so square buttons remain clickable

## Testing
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68e43efff408832e9c2a79afef93dd17