### PR TITLE
Ensure square highlights stay clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,8 @@
         height: 100%;
         padding: 0;
         cursor: pointer;
+        position: relative;
+        z-index: 1;
       }
 
       .square button:focus-visible {
@@ -102,6 +104,7 @@
         position: absolute;
         inset: 6px;
         border-radius: 8px;
+        pointer-events: none;
       }
 
       .highlight-move::after {
@@ -190,6 +193,7 @@
         position: absolute;
         font-size: 0.65rem;
         color: rgba(0, 0, 0, 0.45);
+        pointer-events: none;
       }
 
       .coords.file {


### PR DESCRIPTION
## Summary
- raise the square buttons above highlight overlays so they remain clickable after a move
- ignore pointer events on coordinate labels so they no longer intercept clicks on the board

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43efff408832e9c2a79afef93dd17